### PR TITLE
Web-to-print preparation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,7 +101,7 @@ RUN npm remove puppeteer && \
     PUPPETEER_EXECUTABLE_PATH=`which chromium-browser` PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm install puppeteer && \
     npm install
 # Remove installation packages that are no longer necessary
-RUN apt-get remove -y gcc g++ make g++-10 gcc-10 libgcc-10-dev libstdc++-10-dev libncurses6
+RUN apt-get remove -y gcc g++ make g++-10 gcc-10
 
 WORKDIR /var/www/html
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -100,8 +100,8 @@ RUN apt install -y nodejs && \
 RUN npm remove puppeteer && \
     PUPPETEER_EXECUTABLE_PATH=`which chromium-browser` PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm install puppeteer && \
     npm install
-# Remove installation packages that are not longer necessary
-RUN apt-get remove -y gcc g++ make
+# Remove installation packages that are no longer necessary
+RUN apt-get remove -y gcc g++ make g++-10 gcc-10 libgcc-10-dev libstdc++-10-dev libncurses6
 
 WORKDIR /var/www/html
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -100,6 +100,8 @@ RUN apt install -y nodejs && \
 RUN npm remove puppeteer && \
     PUPPETEER_EXECUTABLE_PATH=`which chromium-browser` PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm install puppeteer && \
     npm install
+# Remove installation packages that are not longer necessary
+RUN apt-get remove -y gcc g++ make
 
 WORKDIR /var/www/html
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -91,7 +91,7 @@ RUN ln -s /usr/bin/chromium /usr/bin/chromium-browser
 RUN npm uninstall node-sass
 # Download node.js in version 18 and install it (incl. dependencies)
 RUN curl -sL https://deb.nodesource.com/setup_18.x | bash - && \
-    apt-get install -y gcc g++ make \
+    apt-get install -y gcc g++ make
 # Install npm and sass
 RUN apt install -y nodejs && \
     npm install -g npm && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,6 +85,22 @@ RUN groupadd -g 1002 app2; \
     useradd -m -d /home/app2 app2 -u 1002 -g app2 -s /bin/bash; \
     chown app2:app2 /home/app2;
 
+# Soft-link Chromium browser
+RUN ln -s /usr/bin/chromium /usr/bin/chromium-browser
+# Uninstall node-sass
+RUN npm uninstall node-sass
+# Download node.js in version 18 and install it (incl. dependencies)
+RUN curl -sL https://deb.nodesource.com/setup_18.x | bash - && \
+    apt-get install -y gcc g++ make \
+# Install npm and sass
+RUN apt install -y nodejs && \
+    npm install -g npm && \
+    npm install sass
+# Remove puppeteer and re-install it with correct information about chromium installation
+RUN npm remove puppeteer && \
+    PUPPETEER_EXECUTABLE_PATH=`which chromium-browser` PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm install puppeteer && \
+    npm install
+
 WORKDIR /var/www/html
 
 CMD ["php-fpm", "--allow-to-run-as-root"]


### PR DESCRIPTION
- Soft-link Chromium browser
- Uninstall node-sass
- Download node.js in version 18 and install it (incl. dependencies)
- Install npm and sass
- Remove puppeteer and re-install it with correct information about chromium installation
- Remove installation packages that are no longer necessary