### PR TITLE
Web-to-print preparation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
 
 env:
     IMAGE_NAME: s1kom/pimcore-test
-    LATEST_TAG: v1.5-alpha
+    LATEST_TAG: v1.5-beta
     DEV_BRANCH: 1.x
 
 jobs:
@@ -23,7 +23,7 @@ jobs:
                 php: [ '8.1' ]
                 distro: [ bullseye ]
                 target: [ fpm, debug, supervisord ]
-                tag: [ 'v1.5-alpha' ]
+                tag: [ 'v1.5-beta' ]
 
         steps:
             -   uses: actions/checkout@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,7 @@ RUN ln -s /usr/bin/chromium /usr/bin/chromium-browser
 # Uninstall node-sass
 RUN npm uninstall node-sass
 # Download node.js in version 18 and install it (incl. dependencies)
-RUN curl -sL https://deb.nodesource.com/setup_18.x | bash - && \
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
     apt-get install -y gcc g++ make
 # Install npm and sass
 RUN apt install -y nodejs && \
@@ -100,8 +100,6 @@ RUN apt install -y nodejs && \
 RUN npm remove puppeteer && \
     PUPPETEER_EXECUTABLE_PATH=`which chromium-browser` PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm install puppeteer && \
     npm install
-# Remove installation packages that are no longer necessary
-RUN apt-get remove -y gcc g++ make g++-10 gcc-10
 
 WORKDIR /var/www/html
 


### PR DESCRIPTION
- Downgrade previously updated node.js version (12.x to 18.x, see https://github.com/studio1gmbh/pimcore-docker/pull/3 / https://github.com/studio1gmbh/pimcore-docker/pull/4) from 18.x to 14.x to ensure Pimcore portal engine commands (see https://pimcore.com/docs/portal-engine/current/Development_Documentation/Customize_Appearance/Customize_Frontend_Build.html) still work (therefore build tools are not removed)